### PR TITLE
ブログ一覧で本文の抜粋を表示する

### DIFF
--- a/src/components/PostExcerpt.astro
+++ b/src/components/PostExcerpt.astro
@@ -15,10 +15,16 @@ const { post } = Astro.props
 <style>
   .post-excerpt {
     padding: 0.2rem 0;
-    font-size: 1rem;
   }
 
   .post-excerpt p {
     margin: 0;
+    color: var(--fg-subtle);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 </style>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -5,6 +5,7 @@ import PostDate from '../components/PostDate.astro'
 import PostTags from '../components/PostTags.astro'
 import PostTitle from '../components/PostTitle.astro'
 import PostFeaturedImage from '../components/PostFeaturedImage.astro'
+import PostExcerpt from '../components/PostExcerpt.astro'
 import Pagination from '../components/Pagination.astro'
 import BlogPostsLink from '../components/BlogPostsLink.astro'
 import BlogTagsLink from '../components/BlogTagsLink.astro'
@@ -43,6 +44,7 @@ const {
                                         </div>
                                     </div>
                                     <PostTitle post={post} />
+                                    <PostExcerpt post={post} />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## 概要
- ブログ一覧の各記事カードに本文の抜粋を追加して、タイトル下に2行まで表示するようにしました
- 抜粋のフォントサイズをタイトルより小さくし、サブカラーで表示することで視認性を向上させました

## テスト
- `npm run lint` （ESLint 9.x が eslint.config.* を要求するため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68d11303dc348328bfc032107610e57c