### PR TITLE
feat: display post dates in Japanese format

### DIFF
--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -162,9 +162,9 @@ export const getDateStr = (date: string) => {
   }
 
   const y = dt.getFullYear()
-  const m = ('00' + (dt.getMonth() + 1)).slice(-2)
-  const d = ('00' + dt.getDate()).slice(-2)
-  return y + '-' + m + '-' + d
+  const m = dt.getMonth() + 1
+  const d = dt.getDate()
+  return `${y}年${m}月${d}日`
 }
 
 export const buildHeadingId = (heading: Heading1 | Heading2 | Heading3) => {


### PR DESCRIPTION
## Summary
- display post publication dates using a Japanese-style format (YYYY年M月D日)

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and npm install is blocked by a 403 when fetching @notionhq/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e0256b9c8328a1190a63c737d474