### PR TITLE
記事詳細ページでタイトル画像を非表示にしタイトルを強調

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -19,7 +19,6 @@ import {
 import Layout from '../../layouts/Layout.astro'
 import PostDate from '../../components/PostDate.astro'
 import PostTags from '../../components/PostTags.astro'
-import PostTitle from '../../components/PostTitle.astro'
 import PostBody from '../../components/PostBody.astro'
 import PostRelativeLink from '../../components/PostRelativeLink.astro'
 import BlogPostsLink from '../../components/BlogPostsLink.astro'
@@ -101,25 +100,13 @@ if (post.FeaturedImage && post.FeaturedImage.Url) {
 >
 <div slot="main" class={styles.main}>
   <div class={styles.post}>
-    {
-      post.FeaturedImage && post.FeaturedImage.Url && (
-        <div class={styles.featuredImage}>
-          <img
-            src={import.meta.env.DEV ? post.FeaturedImage.Url : filePath(new URL(post.FeaturedImage.Url))}
-            alt={post.Title}
-            loading="eager"
-            style="max-width: 100%; height: auto;"
-          />
-        </div>
-      )
-    }
+    <h1 class={styles.postTitle}>{post.Title}</h1>
 <div class={styles.postMeta}>
   <div class={styles.postMetaInner}>
     <PostDate post={post} />
     <PostTags post={post} />
   </div>
 </div>
-    <!-- <PostTitle post={post} enableLink={false} /> -->
     <PostBody blocks={blocks} />
 
       <footer>

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -30,6 +30,13 @@
   flex-direction: row; /* PC表示で左右に表示 */
 }
 
+.postTitle {
+  margin: 0 0 1rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--fg);
+}
+
 .featuredImage {
   max-width: 100%;
   overflow: hidden;
@@ -59,5 +66,9 @@
     flex-direction: column; /* モバイル表示で上下に表示 */
 
     align-items: flex-start; /* 左詰めで表示 */
+  }
+
+  .postTitle {
+    font-size: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- 記事詳細ページからアイキャッチ画像の出力を削除し、本文冒頭にタイトル見出しを追加
- ブログ用スタイルに記事タイトル用クラスを定義してフォントサイズと太字表示を調整

## Testing
- `npm run lint`（失敗：ESLint v9移行に伴う設定ファイル未対応のため）

------
https://chatgpt.com/codex/tasks/task_e_68d1ea6c14388328bfa6fc5d48c9db7b