### PR TITLE
Adjust post body media sizing for mobile affiliate banners

### DIFF
--- a/src/components/PostBody.astro
+++ b/src/components/PostBody.astro
@@ -18,14 +18,14 @@ const { blocks } = Astro.props
     padding: 0.5rem 0;
   }
 
-  .post-body img {
+  .post-body :global(img) {
     max-width: 100%;
     height: auto;
   }
 
-  .post-body iframe,
-  .post-body object,
-  .post-body embed {
+  .post-body :global(iframe),
+  .post-body :global(object),
+  .post-body :global(embed) {
     max-width: 100%;
   }
 </style>


### PR DESCRIPTION
## Summary
- ensure images and embedded contents in post bodies scale to the available width
- prevent affiliate banners and other third-party embeds from overflowing on narrow screens

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file after upgrade to v9)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f00bb89083288174e8e99d9864a1