### PR TITLE
Enable links inside synced blocks and image captions

### DIFF
--- a/src/components/notion-blocks/Caption.astro
+++ b/src/components/notion-blocks/Caption.astro
@@ -1,5 +1,6 @@
 ---
 import { RichText } from '../../lib/interfaces.ts'
+import RichTextComponent from './RichText.astro'
 
 export interface Props {
   richTexts: RichText[]
@@ -9,9 +10,13 @@ const { richTexts } = Astro.props
 ---
 
 {
-  richTexts.length > 0 && richTexts[0].Text.Content && (
+  richTexts.length > 0 && (
     <div class="caption">
-      <div>{richTexts[0].Text.Content}</div>
+      <div>
+        {richTexts.map((richText) => (
+          <RichTextComponent richText={richText} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/notion-blocks/Image.astro
+++ b/src/components/notion-blocks/Image.astro
@@ -16,6 +16,22 @@ if (block.Image.External) {
 } else if (block.Image.File) {
   image = filePath(new URL(block.Image.File.Url))
 }
+
+let imageLink: string | undefined
+if (block.Image.Caption) {
+  for (const richText of block.Image.Caption) {
+    if (richText.Href) {
+      imageLink = richText.Href
+      break
+    }
+    if (richText.Text && richText.Text.Link) {
+      imageLink = richText.Text.Link.Url
+      break
+    }
+  }
+}
+
+const shouldUseLightbox = ENABLE_LIGHTBOX && !imageLink
 ---
 
 <figure class="image">
@@ -23,8 +39,12 @@ if (block.Image.External) {
     image && (
       <div>
         <div>
-          {ENABLE_LIGHTBOX ? (
+          {shouldUseLightbox ? (
             <a data-fslightbox href={image} data-type="image">
+              <img src={image} alt="Image in a image block" loading="lazy" />
+            </a>
+          ) : imageLink ? (
+            <a href={imageLink} target="_blank" rel="noreferrer noopener">
               <img src={image} alt="Image in a image block" loading="lazy" />
             </a>
           ) : (

--- a/src/components/notion-blocks/Paragraph.astro
+++ b/src/components/notion-blocks/Paragraph.astro
@@ -15,9 +15,9 @@ const { block, headings } = Astro.props
 
 <p class={snakeToKebab(block.Paragraph.Color)}>
   {
-    block.Paragraph.RichTexts.map((richText: interfaces.RichText) => {
-      return <Fragment set:html={richText.PlainText} />;
-    })
+    block.Paragraph.RichTexts.map((richText: interfaces.RichText) => (
+      <RichText richText={richText} />
+    ))
   }
   {
     block.Paragraph.Children && (


### PR DESCRIPTION
## Summary
- 段落ブロックを RichText コンポーネント経由で描画し、同期ブロック内でも URL をクリックできるようにしました
- キャプションも RichText を用いて描画し、リンクなどの装飾を保持するようにしました
- 画像ブロックでキャプションに含まれるリンク先を検出し、Lightbox が無効な場合は画像クリックでそのリンクへ遷移できるようにしました

## Testing
- npm run lint *(依存パッケージの 403 エラーにより実行失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68d2af72dfcc83288a94394de40d0ae2