### PR TITLE
スタイル: Notionテーブルの表示を調整

### DIFF
--- a/src/components/notion-blocks/Table.astro
+++ b/src/components/notion-blocks/Table.astro
@@ -45,12 +45,24 @@ const { block } = Astro.props
 
 <style>
   .table {
+    overflow-x: auto;
   }
   .table table {
     margin: 0.6rem 0;
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 320px;
   }
   .table th,
   .table td {
     font-weight: normal;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--card-border, #d9d9d9);
+    vertical-align: top;
+  }
+  .table th {
+    background-color: var(--card-bg, #f7f7f7);
+    font-weight: 600;
+    text-align: left;
   }
 </style>


### PR DESCRIPTION
## Summary
- Notionのテーブルブロックに境界線や背景色を追加し、表として視認しやすいスタイルに更新
- テーブル全体へ余白と横スクロールを付与して、デプロイ環境でも崩れにくいよう調整

## Testing
- npm run lint *(失敗: ESLint が eslint.config.* を検出できませんでした)*

------
https://chatgpt.com/codex/tasks/task_e_68db8ca9865483288578ecd94ca2ba2c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `Table.astro` styling to add horizontal scroll, full-width layout, cell borders/padding, and header background for better readability.
> 
> - **Styles**:
>   - `src/components/notion-blocks/Table.astro`:
>     - Add horizontal scrolling to `.table`.
>     - Set table to `width: 100%`, `border-collapse: collapse`, and `min-width: 320px`.
>     - Add cell `padding`, `border`, and `vertical-align: top` for `.table th, .table td`.
>     - Style headers with background color, increased font weight, and left alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e238cfd31cbfbba581895bd39c6f0d104b8d516f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->