### PR TITLE
fix: TypeScriptエラーを引き起こすコピー処理を修正

### DIFF
--- a/src/components/notion-blocks/Code.astro
+++ b/src/components/notion-blocks/Code.astro
@@ -59,21 +59,32 @@ const lines = highlightedCode.split('\n')
 </script>
 
 <script>
-  document.querySelectorAll('button.copy').forEach((button) => {
-    button.addEventListener('click', (ev) => {
-      navigator.clipboard
-        .writeText(ev.target.getAttribute('data-code'))
-        .then(() => {
-          const originalText = ev.target.innerText
+  document
+    .querySelectorAll<HTMLButtonElement>('button.copy')
+    .forEach((button) => {
+      button.addEventListener('click', (ev) => {
+        const target = ev.currentTarget as HTMLButtonElement | null
+        if (!target) {
+          return
+        }
 
-          ev.target.innerText = ev.target.getAttribute('data-done-text')
+        const codeText = target.dataset.code
+        if (!codeText) {
+          return
+        }
+
+        navigator.clipboard.writeText(codeText).then(() => {
+          const originalText = target.innerText
+          const doneText = target.dataset.doneText ?? 'Copied!'
+
+          target.innerText = doneText
 
           setTimeout(() => {
-            ev.target.innerText = originalText
+            target.innerText = originalText
           }, 3000)
         })
+      })
     })
-  })
 </script>
 
 <style is:global>


### PR DESCRIPTION
## Summary
- コードブロックのコピー処理に型情報とガードを追加し、Problemsタブで発生していた型エラーを解消
- data 属性の読み取りにフォールバックを設け、安全にラベルを書き換えられるように改善

## Testing
- 未実施（npm install が403エラーで失敗するため）

------
https://chatgpt.com/codex/tasks/task_e_68db926f5fc883288f8d1626454f4664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the code block copy handler to use TS-safe element typing, dataset access, and guards with a default done label.
> 
> - **Notion code block (`src/components/notion-blocks/Code.astro`)**:
>   - Refactors copy button handler for TypeScript safety: use `querySelectorAll<HTMLButtonElement>`, `ev.currentTarget`, and `dataset`.
>   - Adds guards for missing target or `data-code`; defaults `data-done-text` to `"Copied!"`.
>   - Preserves and restores original button label after copy via timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629a1719a42c859784e820d6bd6af2158b97c1a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->